### PR TITLE
Add create_membership to the save_organization function

### DIFF
--- a/lib/bywater_web/live/organization_live/form.ex
+++ b/lib/bywater_web/live/organization_live/form.ex
@@ -81,6 +81,14 @@ defmodule BywaterWeb.OrganizationLive.Form do
   defp save_organization(socket, :new, organization_params) do
     case Accounts.create_organization(organization_params) do
       {:ok, organization} ->
+        # Create membership for the current user
+        {:ok, _membership} =
+          Accounts.create_membership(%{
+            user_id: socket.assigns.current_scope.user.id,
+            organization_id: organization.id,
+            role: "admin"
+          })
+
         {:noreply,
          socket
          |> put_flash(:info, "Organization created successfully")


### PR DESCRIPTION
Added the `create_membership` to the `save_organization` function so that we can fill the organization_memberships table with the `organization_id` and the current `user_id`.

```elixir
defp save_organization(socket, :new, organization_params) do
    case Accounts.create_organization(organization_params) do
      {:ok, organization} ->
        # Create membership for the current user
        {:ok, _membership} =
          Accounts.create_membership(%{
            user_id: socket.assigns.current_scope.user.id,
            organization_id: organization.id,
            role: "admin"
          })

        {:noreply,
         socket
         |> put_flash(:info, "Organization created successfully")
         |> push_navigate(to: return_path(socket.assigns.return_to, organization))}

      {:error, %Ecto.Changeset{} = changeset} ->
        {:noreply, assign(socket, form: to_form(changeset))}
    end
  end
```

And now, for all our Organizations

```sql
sqlite> select * from organizations;
id  name      slug    active  inserted_at           updated_at
--  --------  ------  ------  --------------------  --------------------
1   Personel  dhony   1       2025-06-12T17:59:25Z  2025-06-12T17:59:25Z
2   School    school  1       2025-06-12T17:59:59Z  2025-06-12T17:59:59Z
```

We have an user associated to it via the organization_memberships:

```sql
sqlite> select * from organization_memberships;
id  role   user_id  organization_id  inserted_at           updated_at
--  -----  -------  ---------------  --------------------  --------------------
1   admin  1        1                2025-06-12T17:59:25Z  2025-06-12T17:59:25Z
2   admin  1        2                2025-06-12T17:59:59Z  2025-06-12T17:59:59Z
```